### PR TITLE
Quote the project-level configuration when passing it to cloverage.coverage/run-project

### DIFF
--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -38,7 +38,7 @@
                        :test-ns-path (vec (:test-paths project)))]
     (try
       (eval/eval-in-project project
-                            `(cloverage.coverage/run-project ~opts ~@args)
+                            `(cloverage.coverage/run-project '~opts ~@args)
                             '(require 'cloverage.coverage))
       (catch ExceptionInfo e
         (main/exit (:exit-code (ex-data e) 1))))))


### PR DESCRIPTION
Currently the project.clj `:cloverage` configuration is implicitly `eval`ed as it's passed into cloverage, which resulted in issues when merging profiles caused vectors to turn into lists. 😬